### PR TITLE
Trigger 'darkdark' by default

### DIFF
--- a/src/com.undavide.topcoat/js/themeManager.js
+++ b/src/com.undavide.topcoat/js/themeManager.js
@@ -63,7 +63,7 @@ var themeManager = (function() {
 			themeShade = "dark";
 			$("#topcoat").attr("href", "css/topcoat-desktop-dark.min.css");
 		
-		} else if (redShade > 50) { // exact: 52 (#343434)
+		} else { // exact: 52 (#343434)
 			themeShade = "darkdark";
 			$("#topcoat").attr("href", "css/topcoat-desktop-darkdark.min.css");
 		}


### PR DESCRIPTION
Signed-off-by: Chris McGee <chris@chrismcgee.info>

In the latest version of Adobe Illustrator (CC 2018 a.k.a. 22.1), the 'darkdark' theme has a Red value of 50. This means the `updateThemeWithAppSkinInfo()` function never triggers.

This patch will fix the condition-checking so that 'darkdark' will trigger if none of the other three themes are in effect. This assumes, of course, that the user wants the aforementioned function to _always_ trigger and apply one of the four color schemes. Given the purpose of the script, I think this assumption was originally intended anyway.